### PR TITLE
Tristan/docs release ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Run tox inside a container
         run: tox -e docs
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs
+          path: doc/build/html

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,60 @@
+name: Merge actions
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-20.04
+    container: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:31-master-140747994
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Run tox inside a container
+      run: tox -e docs
+    - name: Create docs tarball
+      run: tar -C doc/build/html -zcf docs.tgz .
+    - name: Upload release assets
+      run: |
+        tag_name="${GITHUB_REF##*/}"
+        hub release create -a "docs.tgz" -m "$tag_name" "$tag_name"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish documentation to pages
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: docs
+        path: docs
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+        path: pages
+
+    - name: Update repo
+      run: |
+
+        # Copy the docs asset over and overwrite the orphan gh-pages branch, ensure
+        # that we disable GitHub's jekyll by creating the .nojekyll file, otherwise
+        # it will interfere with the rendering of the site.
+        #
+        cp -a docs/* pages/
+        touch pages/.nojekyll
+
+        cd pages/
+        git add .
+        git config --local user.email "merge-ci@ponyland"
+        git config --local user.name  "Github Actions Nightly Job"
+        git commit -m "Update repo for docs build $GITHUB_RUN_NUMBER"
+        git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Upload Release Asset
+
+on:
+  push:
+    tags:
+    - '*.*.*'
+
+jobs:
+  release:
+    name: Upload Release Asset
+    runs-on: ubuntu-20.04
+    container: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:31-master-140747994
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Run tox inside a container
+      run: tox -e docs
+    - name: Create docs tarball
+      run: tar -C doc/build/html -zcf docs.tgz .
+    - name: Upload release assets
+      run: |
+        tag_name="${GITHUB_REF##*/}"
+        hub release create -a "docs.tgz" -m "$tag_name" "$tag_name"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This merge request:

* Extends pre-merge CI to create a workflow artifact with the docs, so we can observe docs changes in pre-merge stages

* Adds merge.ci, which will run only when we push changes to master, and will update the github pages site with freshly build documentation for master

* Adds release.ci, which will create a github release whenever we push a release tag, this currently only uploads a `docs.tgz` tarball as an accompanying release asset.
